### PR TITLE
Add custom CLI setup action

### DIFF
--- a/.github/actions/setup-cli/action.yml
+++ b/.github/actions/setup-cli/action.yml
@@ -1,0 +1,40 @@
+name: Setup Supabase CLI (Custom)
+description: Install Supabase CLI from a specified GitHub repository
+inputs:
+  version:
+    description: Version of Supabase CLI to install (or "latest")
+    required: false
+    default: latest
+  repo:
+    description: GitHub repository hosting the CLI releases
+    required: false
+    default: supabase/cli
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        set -euo pipefail
+        VERSION="${{ inputs.version }}"
+        REPO="${{ inputs.repo }}"
+        ARCH="$(uname -m)"
+        case "$ARCH" in
+          x86_64) ARCH="amd64" ;;
+          aarch64|arm64) ARCH="arm64" ;;
+        esac
+        OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+        FILE="supabase_${OS}_${ARCH}.tar.gz"
+        if [ "$VERSION" = "latest" ]; then
+          URL="https://github.com/${REPO}/releases/latest/download/${FILE}"
+        else
+          V="${VERSION#v}"
+          cmp=$(printf '%s\n1.28.0\n'$V | sort -V | head -n1)
+          if [ "$cmp" = "$V" ]; then
+            FILE="supabase_${V}_${OS}_${ARCH}.tar.gz"
+          fi
+          URL="https://github.com/${REPO}/releases/download/v${V}/${FILE}"
+        fi
+        echo "Downloading $URL"
+        mkdir -p "$RUNNER_TEMP/supabase-cli"
+        curl -fsSL "$URL" | tar -xz -C "$RUNNER_TEMP/supabase-cli"
+        echo "$RUNNER_TEMP/supabase-cli" >> "$GITHUB_PATH"

--- a/README.md
+++ b/README.md
@@ -162,6 +162,21 @@ npx supabase bootstrap
 ```
 
 The bootstrap command will guide you through the process of setting up a Supabase project using one of the [starter](https://github.com/supabase-community/supabase-samples/blob/main/samples.json) templates.
+### GitHub Actions
+
+Use the bundled action to install the CLI from any GitHub repository.
+Default repository is `supabase/cli` so the action can replace the official setup step.
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+  - uses: ./github/actions/setup-cli
+    with:
+      repo: <owner>/<repo>
+      version: latest
+  - run: supabase --version
+```
+
 
 ## Docs
 


### PR DESCRIPTION
## Summary
- provide `setup-cli` composite action to install the CLI from any GitHub repo
- document how to use the action in README

## Testing
- `go vet ./...` *(fails: Forbidden fetching modules)*

------
https://chatgpt.com/codex/tasks/task_e_6860791a11e08333ba51cc5c1f21c198