### PR TITLE
Add repo/version override for postinstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ When installing with yarn 4, you need to disable experimental fetch with the fol
 NODE_OPTIONS=--no-experimental-fetch yarn add supabase
 ```
 
+You can override the GitHub repository and release used by the installer by setting environment variables.
+Specify `SUPABASE_REPO` for the repository and `SUPABASE_VERSION` for the tag name (use `latest` to fetch the most recent release):
+
+```bash
+SUPABASE_REPO=myorg/cli SUPABASE_VERSION=latest npm i github:myorg/cli --save-dev
+```
+
 > **Note**
 For Bun versions below v1.0.17, you must add `supabase` as a [trusted dependency](https://bun.sh/guides/install/trusted) before running `bun add -D supabase`.
 


### PR DESCRIPTION
## Summary
- allow overriding GitHub repo and version via SUPABASE_REPO and SUPABASE_VERSION env vars
- document how to install from a custom repository

## Testing
- `go test ./... -race -v -count=1 -failfast` *(fails: Forbidden connecting to storage.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_6860f45191788333b91496bc11207a3a