### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,95 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_call:
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  settings:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    outputs:
+      release_tag: ${{ steps.prerelease.outputs.tagName }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: prerelease
+        run: |
+          gh release list --limit 1 --json tagName --jq \
+          '.[]|to_entries|map("\(.key)=\(.value|tostring)")|.[]' >> $GITHUB_OUTPUT
+      - run: gh release edit ${{ steps.prerelease.outputs.tagName }} --latest --prerelease=false
+
+  commit:
+    name: Publish Brew and Scoop
+    needs:
+      - settings
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - run: go run tools/publish/main.go ${{ needs.settings.outputs.release_tag }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+
+  publish:
+    name: Publish NPM
+    needs:
+      - settings
+    uses: ./.github/workflows/tag-npm.yml
+    with:
+      release: ${{ needs.settings.outputs.release_tag }}
+    secrets: inherit
+
+  compose:
+    name: Bump self-hosted versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - run: go run tools/selfhost/main.go
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+
+  changelog:
+    name: Publish changelog
+    needs:
+      - commit
+      - publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - run: go run tools/changelog/main.go ${{ secrets.SLACK_CHANNEL }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+
+  docs:
+    name: Publish reference docs
+    needs:
+      - settings
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - run: go run docs/main.go ${{ needs.settings.outputs.release_tag }} | go run tools/bumpdoc/main.go apps/docs/spec/cli_v1_commands.yaml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}

--- a/.github/workflows/tag-npm.yml
+++ b/.github/workflows/tag-npm.yml
@@ -1,0 +1,32 @@
+name: Tag NPM
+
+on:
+  workflow_call:
+    inputs:
+      release:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      release:
+        description: "v1.0.0"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  tag:
+    name: Move latest tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "16.x"
+          registry-url: "https://registry.npmjs.org"
+      - run: npm dist-tag add "supabase@${RELEASE_TAG#v}" latest
+        env:
+          RELEASE_TAG: ${{ inputs.release }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,10 @@
 
 ## Release process
 
-We release to stable channel every two weeks.
+We publish a new stable release automatically whenever commits are pushed to the
+`main` branch.
 
-We release to beta channel on merge to `main` branch.
+Beta releases are created from the `develop` branch.
 
 Hotfixes are released manually. Follow these steps:
 


### PR DESCRIPTION
## Summary
- restore release workflow to publish on push to `main`
- document automated releases in CONTRIBUTING guide

## Testing
- `go test ./... -race -v -count=1 -failfast` *(fails: cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6860fd718914833382e96ca5eb50d35d