### PR TITLE
Fix release workflow tag retrieval

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,8 @@ jobs:
       - uses: actions/checkout@v4
       - id: prerelease
         run: |
-          gh release list --limit 1 --json tagName --jq \
-          '.[]|to_entries|map("\(.key)=\(.value|tostring)")|.[]' >> $GITHUB_OUTPUT
+          tag=$(gh release list --limit 1 --json tagName --jq '.[0].tagName')
+          echo "tagName=$tag" >> "$GITHUB_OUTPUT"
       - run: gh release edit ${{ steps.prerelease.outputs.tagName }} --latest --prerelease=false
 
   commit:


### PR DESCRIPTION
## Summary
- ensure `gh release edit` uses a fetched tag from `gh release list`

## Testing
- `go test ./... -list .` *(fails: context deadline exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_6860ffb05ba48333a3f2cb5341999e9c