### PR TITLE
Fix release tag retrieval in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,9 @@ jobs:
           if [ -z "$tag" ]; then
             tag=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r .tag_name)
           fi
+          if [ "$tag" = "null" ] || [ -z "$tag" ]; then
+            tag=$(curl -s https://api.github.com/repos/supabase/cli/releases/latest | jq -r .tag_name)
+          fi
           echo "tagName=$tag" >> "$GITHUB_OUTPUT"
       - run: gh release edit ${{ steps.prerelease.outputs.tagName }} --latest --prerelease=false
 


### PR DESCRIPTION
## Summary
- handle no release scenario in release workflow by falling back to the upstream repository

## Testing
- `go test ./... -race -v -count=1 -failfast` *(fails: cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6861128322ac8333bc5874b84c2e98be